### PR TITLE
fix: SyntaxError

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -16,6 +16,7 @@ const config = {
           "width=device-width, initial-scale=1"
       },
     ],
+  },
   /**
    * Webpack build
    */


### PR DESCRIPTION
nuxt.config.js에서 head 설정의 "}"과 빠져서 아래와 같은 오류가 발생해서 수정했어요.

```bash
 ERROR  Invalid or unexpected token                                                                   

  export default () => (config)
  ^

  SyntaxError: Invalid or unexpected token
  at Object.Module._extensions..js (internal/modules/cjs/loader.js:732:10)

✨  Done in 0.36s.
```